### PR TITLE
sysrq: Emergency Remount R/O in reverse order

### DIFF
--- a/fs/super.c
+++ b/fs/super.c
@@ -789,7 +789,7 @@ static void do_emergency_remount(struct work_struct *work)
 	struct super_block *sb, *p = NULL;
 
 	spin_lock(&sb_lock);
-	list_for_each_entry(sb, &super_blocks, s_list) {
+	list_for_each_entry_reverse(sb, &super_blocks, s_list) {
 		if (hlist_unhashed(&sb->s_instances))
 			continue;
 		sb->s_count++;


### PR DESCRIPTION
This change fixes a problem where reboot on Android panics the kernel
almost every time when file systems are mounted over loop devices.

Android reboot command does:
- sync
- echo u > /proc/sysrq-trigger
- syscall_reboot

The problem is with sysrq emergency remount R/O trying to remount-ro
in wrong order.
since /data is re-mounted ro before loop devices, loop device
remount-ro fails to flush the journal and panics the kernel:

  EXT4-fs (loop0): Remounting filesystem read-only
  EXT4-fs (loop0): previous I/O error to superblock detected
  loop: Write error at byte offset 0, length 4096.
  Buffer I/O error on device loop0, logical block 0
  lost page write due to I/O error on loop0
  Kernel panic - not syncing: EXT4-fs panic from previous error

The fix is quite simple. In do_emergency_remount(), use
list_for_each_entry_reverse() on sb list instead of list_for_each_entry().
It makes a lot of sense to umount the file systems in reverse order in
which they were added to sb list.

Change-Id: I4370e39b5873bd16ade5d5f9ddb2704beb02a2bb
Signed-off-by: Amir Goldstein <amir@cellrox.com>
Acked-by: Oren Laadan <orenl@cellrox.com>