### PR TITLE
mm: change max readahead size to 512KB

### DIFF
--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -1453,7 +1453,7 @@ int write_one_page(struct page *page, int wait);
 void task_dirty_inc(struct task_struct *tsk);
 
 /* readahead.c */
-#define VM_MAX_READAHEAD	128	/* kbytes */
+#define VM_MAX_READAHEAD	512	/* kbytes */
 #define VM_MIN_READAHEAD	16	/* kbytes (includes current page) */
 
 int force_page_cache_readahead(struct address_space *mapping, struct file *filp,


### PR DESCRIPTION
Change the VM_MAX_READAHEAD value from the default 128KB
to 512KB. This will allow the readahead window to grow to a maximum size
of 512KB, which greatly benefits to sequential read throughput.

Change-Id: Ia0780ea4e2a4ae0b6111485b72fb25376dcb1f96
Signed-off-by: Lee Susman <lsusman@codeaurora.org>